### PR TITLE
Screen reader accessibility

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -902,8 +902,12 @@ document.getElementById("colorToggle").addEventListener("click", (e) => {
   const btn = e.target.closest("button");
   if (!btn || !btn.dataset.mode) return;
   colorMode = btn.dataset.mode;
-  document.querySelectorAll("#colorToggle button").forEach(b => b.classList.remove("active"));
+  document.querySelectorAll("#colorToggle button").forEach(b => {
+    b.classList.remove("active");
+    b.setAttribute("aria-pressed", "false");
+  });
   btn.classList.add("active");
+  btn.setAttribute("aria-pressed", "true");
   updateStats();
   drawGradientLegend();
   draw();

--- a/site/index.html
+++ b/site/index.html
@@ -218,7 +218,7 @@ canvas#canvas {
 <body>
 
 <div id="wrapper">
-<div id="header">
+<header id="header">
   <div class="intro">
     <h1>US Job Market Visualizer <a href="https://github.com/karpathy/jobs">GitHub</a></h1>
     <p>This is a research tool that visualizes <b>342 occupations</b> from the <a href="https://www.bls.gov/ooh/">Bureau of Labor Statistics Occupational Outlook Handbook</a>, covering <b>143M jobs</b> across the US economy. Each rectangle's <b>area</b> is proportional to total employment. <b>Color</b> shows the selected metric &mdash; toggle between BLS projected growth outlook, median pay, education requirements, and AI exposure. Click any tile to view its full BLS page. This is not a report, a paper, or a serious economic publication &mdash; it is a development tool for exploring BLS data visually.</p>
@@ -252,20 +252,23 @@ Respond with ONLY a JSON object in this exact format, no other text:
     </details>
     <p><b>Caveat on Digital AI Exposure scores:</b> These are rough LLM estimates, not rigorous predictions. A high score does not predict the job will disappear. Software developers score 9/10 because AI is transforming their work &mdash; but demand for software could easily <em>grow</em> as each developer becomes more productive. The score does not account for demand elasticity, latent demand, regulatory barriers, or social preferences for human workers. Many high-exposure jobs will be reshaped, not replaced.</p>
   </div>
+</header>
 
+<main>
+<h2 class="sr-only">Dashboard</h2>
   <div class="controls-row">
     <div class="stat-section">
       <h3>Layer</h3>
       <div class="color-toggle" id="colorToggle">
-        <button data-mode="outlook" class="active">BLS Outlook</button>
-        <button data-mode="pay">Median Pay</button>
-        <button data-mode="education">Education</button>
-        <button data-mode="exposure">Digital AI Exposure</button>
+        <button data-mode="outlook" class="active" aria-pressed="true">BLS Outlook</button>
+        <button data-mode="pay" aria-pressed="false">Median Pay</button>
+        <button data-mode="education" aria-pressed="false">Education</button>
+        <button data-mode="exposure" aria-pressed="false">Digital AI Exposure</button>
       </div>
     </div>
     <div class="gradient-legend">
       <span id="legendLow">Declining</span>
-      <canvas id="gradientLegend" width="80" height="8"></canvas>
+      <canvas id="gradientLegend" width="80" height="8" aria-hidden="true"></canvas>
       <span id="legendHigh">Growing</span>
     </div>
   </div>
@@ -283,12 +286,14 @@ Respond with ONLY a JSON object in this exact format, no other text:
     <div class="stat-section" id="block7"></div>
     <div class="stat-section" id="block8"></div>
   </div>
+
+<div class="sr-only" id="srTable"></div>
+<div class="sr-only" aria-live="polite" id="liveAnnounce"></div>
+<canvas id="canvas" aria-hidden="true"></canvas>
+</main>
 </div>
 
-<canvas id="canvas"></canvas>
-</div>
-
-<div id="tooltip">
+<div id="tooltip" aria-hidden="true">
   <div class="tt-title"></div>
   <div class="tt-exposure"></div>
   <div class="tt-stats"></div>

--- a/site/index.html
+++ b/site/index.html
@@ -862,6 +862,17 @@ function updateExposureStats(totalJobs) {
   document.getElementById("block8").innerHTML = "";
 }
 
+function announceLayerChange() {
+  const btn = document.querySelector("#colorToggle button.active");
+  const block = document.getElementById("block2");
+  const metric = block.querySelector("h3");
+  const value = block.querySelector(".stat-big");
+  const el = document.getElementById("liveAnnounce");
+  el.textContent = "Switched to " + (btn ? btn.textContent : "") + ". " +
+    (metric ? metric.textContent : "") + ": " +
+    (value ? value.textContent : "");
+}
+
 // ── Events ─────────────────────────────────────────────────────────────
 
 canvas.addEventListener("mousemove", (e) => {
@@ -909,6 +920,7 @@ document.getElementById("colorToggle").addEventListener("click", (e) => {
   btn.classList.add("active");
   btn.setAttribute("aria-pressed", "true");
   updateStats();
+  announceLayerChange();
   drawGradientLegend();
   draw();
   // Re-layout since stats height may have changed

--- a/site/index.html
+++ b/site/index.html
@@ -202,6 +202,17 @@ canvas#canvas {
 #tooltip .tt-stats .label { color: var(--fg2); }
 #tooltip .tt-stats .value { color: var(--fg); text-align: right; }
 #tooltip .tt-rationale { font-size: 11px; color: var(--fg2); margin-top: 8px; line-height: 1.4; border-top: 1px solid rgba(255,255,255,0.06); padding-top: 8px; }
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
 </style>
 </head>
 <body>

--- a/site/index.html
+++ b/site/index.html
@@ -862,6 +862,39 @@ function updateExposureStats(totalJobs) {
   document.getElementById("block8").innerHTML = "";
 }
 
+function buildAccessibleTable() {
+  const container = document.getElementById("srTable");
+  const sorted = [...data].sort((a, b) => {
+    const cat = a.category.localeCompare(b.category);
+    if (cat !== 0) return cat;
+    return (b.jobs || 0) - (a.jobs || 0);
+  });
+  const rows = sorted.map(d =>
+    `<tr>
+      <td><a href="${d.url}" target="_blank" rel="noopener">${d.title}<span class="sr-only"> (opens in new tab)</span></a></td>
+      <td>${d.category.replace(/-/g, " ")}</td>
+      <td>${d.jobs != null ? d.jobs.toLocaleString() : "\u2014"}</td>
+      <td>${d.pay != null ? "$" + d.pay.toLocaleString() : "\u2014"}</td>
+      <td>${d.outlook != null ? (d.outlook > 0 ? "+" : "") + d.outlook + "%" : "\u2014"}${d.outlook_desc ? " (" + d.outlook_desc + ")" : ""}</td>
+      <td>${d.education || "\u2014"}</td>
+      <td>${d.exposure != null ? d.exposure + "/10" : "\u2014"}</td>
+    </tr>`
+  ).join("");
+  container.innerHTML = `<table>
+    <caption>${data.length} occupations from the Bureau of Labor Statistics Occupational Outlook Handbook. The AI Exposure column contains LLM-generated estimates, not BLS data.</caption>
+    <thead><tr>
+      <th scope="col">Title</th>
+      <th scope="col">Category</th>
+      <th scope="col">Jobs</th>
+      <th scope="col">Median Pay</th>
+      <th scope="col">Outlook</th>
+      <th scope="col">Education</th>
+      <th scope="col">AI Exposure</th>
+    </tr></thead>
+    <tbody>${rows}</tbody>
+  </table>`;
+}
+
 function announceLayerChange() {
   const btn = document.querySelector("#colorToggle button.active");
   const block = document.getElementById("block2");
@@ -933,6 +966,7 @@ fetch("data.json")
   .then(r => r.json())
   .then(d => {
     data = d;
+    buildAccessibleTable();
     updateStats();
     drawGradientLegend();
     resize();


### PR DESCRIPTION
## Overview

The treemap visualization is currently canvas-based, which means that screen readers can't interpret any of the 342 occupations or interact with the page in a meaningful way. There are also no landmark regions, the heading hierarchy skips levels, toggle buttons don't expose their active state, and stat updates are silent when switching layers.

This PR fixes all of these issues, while leaving the pre-existing visual design unchanged.

## Changes

- Added a visually hidden HTML table containing all occupation data (title, category, jobs, pay, outlook, education, AI exposure) so screen readers can browse the full dataset. Each occupation links to its corresponding BLS page.
- Wrapped the page in proper landmark elements (`<header>`, `<main>`) and added a hidden `<h2>` to aid in navigation and fix the heading hierarchy (was jumping from h1 to h3).
- Set `aria-pressed` on the layer toggle buttons so screen readers announce which layer is active. This updates dynamically when the user switches layers.
- Added an `aria-live` region that announces a short summary when the layer changes (e.g. "Switched to Median Pay. Avg. pay: $58K")
- Marked both canvases and the tooltip with `aria-hidden="true"` since they're redundant with the table and not keyboard-accessible anyway.

## Testing

- [x] Opened the site in a browser and confirmed the page looks identical to before. There are no layout shifts, visible text from sr-only elements, or changes to treemap rendering or interaction.
- [x] Inspected the DOM to verify correct landmark nesting, heading order, aria attributes on all buttons and canvases, table row count (342), and live region updates on layer switch.
- [x] Tested with a screen reader: navigated by landmarks (banner/main), headings (h1/h2/h3), and table. Confirmed button states announce correctly, layer changes trigger live announcements, and table links open BLS pages in new tabs.