### PR TITLE
Add AI Opportunity layers: Advantage, Growth, and composite

### DIFF
--- a/build_site_data.py
+++ b/build_site_data.py
@@ -1,8 +1,9 @@
 """
-Build a compact JSON for the website by merging CSV stats with AI exposure scores.
+Build a compact JSON for the website by merging CSV stats with AI scores.
 
-Reads occupations.csv (for stats) and scores.json (for AI exposure).
-Writes site/data.json.
+Reads occupations.csv (for stats), scores.json (for AI exposure), and
+optionally scores_advantage.json and scores_growth.json for the opportunity
+layers. Writes site/data.json.
 
 Usage:
     uv run python build_site_data.py
@@ -10,13 +11,22 @@ Usage:
 
 import csv
 import json
+import os
+
+
+def load_scores(path):
+    """Load a scores JSON file, returning a slug-keyed dict (empty if missing)."""
+    if not os.path.exists(path):
+        return {}
+    with open(path) as f:
+        return {s["slug"]: s for s in json.load(f)}
 
 
 def main():
-    # Load AI exposure scores
-    with open("scores.json") as f:
-        scores_list = json.load(f)
-    scores = {s["slug"]: s for s in scores_list}
+    # Load all score files
+    scores = load_scores("scores.json")
+    scores_adv = load_scores("scores_advantage.json")
+    scores_gro = load_scores("scores_growth.json")
 
     # Load CSV stats
     with open("occupations.csv") as f:
@@ -28,6 +38,15 @@ def main():
     for row in rows:
         slug = row["slug"]
         score = scores.get(slug, {})
+        adv = scores_adv.get(slug, {})
+        gro = scores_gro.get(slug, {})
+
+        advantage = adv.get("advantage")
+        growth = gro.get("growth")
+        opportunity = None
+        if advantage is not None and growth is not None:
+            opportunity = round((advantage + growth) / 2, 1)
+
         data.append({
             "title": row["title"],
             "slug": slug,
@@ -39,10 +58,14 @@ def main():
             "education": row["entry_education"],
             "exposure": score.get("exposure"),
             "exposure_rationale": score.get("rationale"),
+            "advantage": advantage,
+            "advantage_rationale": adv.get("rationale"),
+            "growth": growth,
+            "growth_rationale": gro.get("rationale"),
+            "opportunity": opportunity,
             "url": row.get("url", ""),
         })
 
-    import os
     os.makedirs("site", exist_ok=True)
     with open("site/data.json", "w") as f:
         json.dump(data, f)
@@ -50,6 +73,13 @@ def main():
     print(f"Wrote {len(data)} occupations to site/data.json")
     total_jobs = sum(d["jobs"] for d in data if d["jobs"])
     print(f"Total jobs represented: {total_jobs:,}")
+
+    # Report which layers have data
+    for label, key in [("exposure", "exposure"), ("advantage", "advantage"),
+                       ("growth", "growth"), ("opportunity", "opportunity")]:
+        count = sum(1 for d in data if d[key] is not None)
+        if count:
+            print(f"  {label}: {count} scored")
 
 
 if __name__ == "__main__":

--- a/make_prompt.py
+++ b/make_prompt.py
@@ -9,6 +9,7 @@ Usage:
 
 import csv
 import json
+import os
 
 
 def fmt_pay(pay):
@@ -38,14 +39,29 @@ def main():
     with open("scores.json") as f:
         scores = {s["slug"]: s for s in json.load(f)}
 
+    scores_adv = {}
+    if os.path.exists("scores_advantage.json"):
+        with open("scores_advantage.json") as f:
+            scores_adv = {s["slug"]: s for s in json.load(f)}
+
+    scores_gro = {}
+    if os.path.exists("scores_growth.json"):
+        with open("scores_growth.json") as f:
+            scores_gro = {s["slug"]: s for s in json.load(f)}
+
     # Merge into unified records
     records = []
     for occ in occupations:
         slug = occ["slug"]
         row = csv_rows.get(slug, {})
         score = scores.get(slug, {})
+        adv = scores_adv.get(slug, {})
+        gro = scores_gro.get(slug, {})
         pay = int(row["median_pay_annual"]) if row.get("median_pay_annual") else None
         jobs = int(row["num_jobs_2024"]) if row.get("num_jobs_2024") else None
+        advantage = adv.get("advantage")
+        growth = gro.get("growth")
+        opportunity = round((advantage + growth) / 2, 1) if advantage is not None and growth is not None else None
         records.append({
             "title": occ["title"],
             "slug": slug,
@@ -57,6 +73,11 @@ def main():
             "education": row.get("entry_education", ""),
             "exposure": score.get("exposure"),
             "rationale": score.get("rationale", ""),
+            "advantage": advantage,
+            "advantage_rationale": adv.get("rationale", ""),
+            "growth": growth,
+            "growth_rationale": gro.get("rationale", ""),
+            "opportunity": opportunity,
             "url": occ.get("url", ""),
         })
 
@@ -195,6 +216,8 @@ def main():
     lines.append("Sorted by AI exposure (descending), then by number of jobs (descending).")
     lines.append("")
 
+    has_opp = any(r["advantage"] is not None for r in records)
+
     for score in range(10, -1, -1):
         group = [r for r in records if r["exposure"] == score]
         if not group:
@@ -202,8 +225,12 @@ def main():
         group_jobs = sum(r["jobs"] or 0 for r in group)
         lines.append(f"### Exposure {score}/10 ({len(group)} occupations, {fmt_jobs(group_jobs)} jobs)")
         lines.append("")
-        lines.append("| # | Occupation | Pay | Jobs | Outlook | Education | Rationale |")
-        lines.append("|---|-----------|-----|------|---------|-----------|-----------|")
+        if has_opp:
+            lines.append("| # | Occupation | Pay | Jobs | Outlook | Education | Exposure | Advantage | Growth | Opportunity | Rationale |")
+            lines.append("|---|-----------|-----|------|---------|-----------|----------|-----------|--------|-------------|-----------|")
+        else:
+            lines.append("| # | Occupation | Pay | Jobs | Outlook | Education | Rationale |")
+            lines.append("|---|-----------|-----|------|---------|-----------|-----------|")
         for i, r in enumerate(group, 1):
             outlook = f"{r['outlook_pct']:+d}%" if r["outlook_pct"] is not None else "?"
             edu = r["education"] if r["education"] else "?"
@@ -220,7 +247,13 @@ def main():
                 "See How to Become One": "Varies",
             }.get(edu, edu)
             rationale = r["rationale"].replace("|", "/").replace("\n", " ")
-            lines.append(f"| {i} | {r['title']} | {fmt_pay(r['pay'])} | {fmt_jobs(r['jobs'])} | {outlook} | {edu_short} | {rationale} |")
+            if has_opp:
+                adv_s = str(r["advantage"]) if r["advantage"] is not None else "?"
+                gro_s = str(r["growth"]) if r["growth"] is not None else "?"
+                opp_s = str(r["opportunity"]) if r["opportunity"] is not None else "?"
+                lines.append(f"| {i} | {r['title']} | {fmt_pay(r['pay'])} | {fmt_jobs(r['jobs'])} | {outlook} | {edu_short} | {score}/10 | {adv_s}/10 | {gro_s}/10 | {opp_s}/10 | {rationale} |")
+            else:
+                lines.append(f"| {i} | {r['title']} | {fmt_pay(r['pay'])} | {fmt_jobs(r['jobs'])} | {outlook} | {edu_short} | {rationale} |")
         lines.append("")
 
     # Write

--- a/score.py
+++ b/score.py
@@ -1,14 +1,16 @@
 """
-Score each occupation's AI exposure using an LLM via OpenRouter.
+Score each occupation's AI exposure, advantage, or growth using an LLM via OpenRouter.
 
 Reads Markdown descriptions from pages/, sends each to an LLM with a scoring
 rubric, and collects structured scores. Results are cached incrementally to
-scores.json so the script can be resumed if interrupted.
+a per-metric JSON file so the script can be resumed if interrupted.
 
 Usage:
-    uv run python score.py
+    uv run python score.py                        # default: exposure
+    uv run python score.py --metric advantage
+    uv run python score.py --metric growth
     uv run python score.py --model google/gemini-3-flash-preview
-    uv run python score.py --start 0 --end 10   # test on first 10
+    uv run python score.py --start 0 --end 10     # test on first 10
 """
 
 import argparse
@@ -21,10 +23,11 @@ from dotenv import load_dotenv
 load_dotenv()
 
 DEFAULT_MODEL = "google/gemini-3-flash-preview"
-OUTPUT_FILE = "scores.json"
 API_URL = "https://openrouter.ai/api/v1/chat/completions"
 
-SYSTEM_PROMPT = """\
+# ── Metric configs ────────────────────────────────────────────────────────
+
+EXPOSURE_PROMPT = """\
 You are an expert analyst evaluating how exposed different occupations are to \
 AI. You will be given a detailed description of an occupation from the Bureau \
 of Labor Statistics.
@@ -84,8 +87,107 @@ Respond with ONLY a JSON object in this exact format, no other text:
 }\
 """
 
+ADVANTAGE_PROMPT = """\
+You are an expert analyst evaluating how much workers in different occupations \
+can benefit from adopting AI tools. You will be given a detailed description \
+of an occupation from the Bureau of Labor Statistics.
 
-def score_occupation(client, text, model):
+Rate the occupation's **AI Advantage** on a scale from 0 to 10.
+
+AI Advantage measures: how much can a worker in this occupation amplify their \
+productivity and competitive edge by adopting AI tools? Consider:
+- Can AI automate repetitive parts of their work, freeing time for higher-value tasks?
+- Does using AI tools create a meaningful gap between adopters and non-adopters?
+- How much faster/better can the core work product become with AI assistance?
+
+Use these anchors to calibrate your score:
+
+- **0–1: Minimal.** Work is physical/manual, AI tools barely relevant. \
+Examples: roofer, landscaper.
+
+- **2–3: Low.** Mostly hands-on; AI helps with paperwork but not core work. \
+Examples: electrician, firefighter.
+
+- **4–5: Moderate.** Mix of physical and knowledge work; AI assists the desk portions. \
+Examples: nurse, veterinarian.
+
+- **6–7: High.** Mostly knowledge work; AI tools already boost productivity significantly. \
+Examples: teacher, accountant.
+
+- **8–9: Very high.** Almost entirely digital; AI copilots transform every core task. \
+Examples: software developer, graphic designer.
+
+- **10: Maximum.** AI can handle nearly all tasks; early adopters are dramatically more productive. \
+Examples: data entry clerk.
+
+Respond with ONLY a JSON object in this exact format, no other text:
+{
+  "advantage": <0-10>,
+  "rationale": "<2-3 sentences explaining the key factors>"
+}\
+"""
+
+GROWTH_PROMPT = """\
+You are an expert analyst evaluating how AI will affect demand for different \
+occupations. You will be given a detailed description of an occupation from \
+the Bureau of Labor Statistics.
+
+Rate the occupation's **AI Growth** on a scale from 0 to 10.
+
+AI Growth measures: how much will AI expand demand, create new sub-roles, or \
+grow the market for this occupation? Consider:
+- Will AI make this service cheaper/faster, unlocking latent demand?
+- Does AI create new problem domains that need this occupation?
+- Will productivity gains lead to more hiring (elastic demand) or less (inelastic)?
+- Are there regulatory, trust, or social factors that sustain or grow demand?
+
+Use these anchors to calibrate your score:
+
+- **0–1: Shrinking.** AI directly replaces demand; fewer workers needed. \
+Examples: data entry clerk, telemarketer.
+
+- **2–3: Flat.** AI doesn't meaningfully change demand. \
+Examples: roofer, bus driver.
+
+- **4–5: Stable+.** New AI-adjacent demand roughly offsets automation. \
+Examples: accountant, paralegal.
+
+- **6–7: Growing.** AI creates meaningful new demand or accessibility. \
+Examples: nurse, teacher, trades.
+
+- **8–9: Strongly growing.** AI opens major new markets or sub-specialties. \
+Examples: cybersecurity analyst, data engineer.
+
+- **10: Explosive.** Entirely new demand driven by AI. \
+Examples: AI/ML engineer, prompt engineer.
+
+Respond with ONLY a JSON object in this exact format, no other text:
+{
+  "growth": <0-10>,
+  "rationale": "<2-3 sentences explaining the key factors>"
+}\
+"""
+
+METRIC_CONFIG = {
+    "exposure": {
+        "prompt": EXPOSURE_PROMPT,
+        "output_file": "scores.json",
+        "score_key": "exposure",
+    },
+    "advantage": {
+        "prompt": ADVANTAGE_PROMPT,
+        "output_file": "scores_advantage.json",
+        "score_key": "advantage",
+    },
+    "growth": {
+        "prompt": GROWTH_PROMPT,
+        "output_file": "scores_growth.json",
+        "score_key": "growth",
+    },
+}
+
+
+def score_occupation(client, text, model, system_prompt):
     """Send one occupation to the LLM and parse the structured response."""
     response = client.post(
         API_URL,
@@ -95,7 +197,7 @@ def score_occupation(client, text, model):
         json={
             "model": model,
             "messages": [
-                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "system", "content": system_prompt},
                 {"role": "user", "content": text},
             ],
             "temperature": 0.2,
@@ -119,12 +221,20 @@ def score_occupation(client, text, model):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--metric", default="exposure",
+                        choices=["exposure", "advantage", "growth"],
+                        help="Which metric to score (default: exposure)")
     parser.add_argument("--start", type=int, default=0)
     parser.add_argument("--end", type=int, default=None)
     parser.add_argument("--delay", type=float, default=0.5)
     parser.add_argument("--force", action="store_true",
                         help="Re-score even if already cached")
     args = parser.parse_args()
+
+    cfg = METRIC_CONFIG[args.metric]
+    output_file = cfg["output_file"]
+    score_key = cfg["score_key"]
+    system_prompt = cfg["prompt"]
 
     with open("occupations.json") as f:
         occupations = json.load(f)
@@ -133,12 +243,13 @@ def main():
 
     # Load existing scores
     scores = {}
-    if os.path.exists(OUTPUT_FILE) and not args.force:
-        with open(OUTPUT_FILE) as f:
+    if os.path.exists(output_file) and not args.force:
+        with open(output_file) as f:
             for entry in json.load(f):
                 scores[entry["slug"]] = entry
 
-    print(f"Scoring {len(subset)} occupations with {args.model}")
+    print(f"Scoring {len(subset)} occupations for '{args.metric}' with {args.model}")
+    print(f"Output: {output_file}")
     print(f"Already cached: {len(scores)}")
 
     errors = []
@@ -161,19 +272,19 @@ def main():
         print(f"  [{i+1}/{len(subset)}] {occ['title']}...", end=" ", flush=True)
 
         try:
-            result = score_occupation(client, text, args.model)
+            result = score_occupation(client, text, args.model, system_prompt)
             scores[slug] = {
                 "slug": slug,
                 "title": occ["title"],
                 **result,
             }
-            print(f"exposure={result['exposure']}")
+            print(f"{score_key}={result[score_key]}")
         except Exception as e:
             print(f"ERROR: {e}")
             errors.append(slug)
 
         # Save after each one (incremental checkpoint)
-        with open(OUTPUT_FILE, "w") as f:
+        with open(output_file, "w") as f:
             json.dump(list(scores.values()), f, indent=2)
 
         if i < len(subset) - 1:
@@ -186,14 +297,14 @@ def main():
         print(f"Errors: {errors}")
 
     # Summary stats
-    vals = [s for s in scores.values() if "exposure" in s]
+    vals = [s for s in scores.values() if score_key in s]
     if vals:
-        avg = sum(s["exposure"] for s in vals) / len(vals)
+        avg = sum(s[score_key] for s in vals) / len(vals)
         by_score = {}
         for s in vals:
-            bucket = s["exposure"]
+            bucket = s[score_key]
             by_score[bucket] = by_score.get(bucket, 0) + 1
-        print(f"\nAverage exposure across {len(vals)} occupations: {avg:.1f}")
+        print(f"\nAverage {score_key} across {len(vals)} occupations: {avg:.1f}")
         print("Distribution:")
         for k in sorted(by_score):
             print(f"  {k}: {'█' * by_score[k]} ({by_score[k]})")

--- a/site/index.html
+++ b/site/index.html
@@ -240,6 +240,7 @@ Respond with ONLY a JSON object in this exact format, no other text:
 {"exposure": &lt;0-10&gt;, "rationale": "&lt;2-3 sentences explaining the key factors&gt;"}</div>
     </details>
     <p><b>Caveat on Digital AI Exposure scores:</b> These are rough LLM estimates, not rigorous predictions. A high score does not predict the job will disappear. Software developers score 9/10 because AI is transforming their work &mdash; but demand for software could easily <em>grow</em> as each developer becomes more productive. The score does not account for demand elasticity, latent demand, regulatory barriers, or social preferences for human workers. Many high-exposure jobs will be reshaped, not replaced.</p>
+    <p><b>AI Opportunity layers:</b> To complement the exposure view, three positive-framing layers are available. <b>AI Advantage</b> (0&ndash;10) measures how much a worker can amplify their productivity by adopting AI tools. <b>AI Growth</b> (0&ndash;10) measures how much AI will expand demand or create new roles for an occupation. <b>AI Opportunity</b> is the composite average of Advantage and Growth. Green = high opportunity.</p>
   </div>
 
   <div class="controls-row">
@@ -250,6 +251,9 @@ Respond with ONLY a JSON object in this exact format, no other text:
         <button data-mode="pay">Median Pay</button>
         <button data-mode="education">Education</button>
         <button data-mode="exposure">Digital AI Exposure</button>
+        <button data-mode="advantage">AI Advantage</button>
+        <button data-mode="growth">AI Growth</button>
+        <button data-mode="opportunity">AI Opportunity</button>
       </div>
     </div>
     <div class="gradient-legend">
@@ -343,8 +347,25 @@ function exposureColor(v, a) {
   return greenRedCSS(v / 10, a);
 }
 
+// Green-positive: same green-red scale but flipped (high=green=good)
+function advantageColor(v, a) {
+  if (v == null) return `rgba(128,128,128,${a})`;
+  return greenRedCSS(1 - v / 10, a);
+}
+function growthColor(v, a) {
+  if (v == null) return `rgba(128,128,128,${a})`;
+  return greenRedCSS(1 - v / 10, a);
+}
+function opportunityColor(v, a) {
+  if (v == null) return `rgba(128,128,128,${a})`;
+  return greenRedCSS(1 - v / 10, a);
+}
+
 function tileColorCSS(d, alpha) {
   if (colorMode === "exposure") return exposureColor(d.exposure, alpha);
+  if (colorMode === "advantage") return advantageColor(d.advantage, alpha);
+  if (colorMode === "growth") return growthColor(d.growth, alpha);
+  if (colorMode === "opportunity") return opportunityColor(d.opportunity, alpha);
   if (colorMode === "outlook") return outlookColor(d.outlook, alpha);
   if (colorMode === "pay") return payColor(d.pay, alpha);
   if (colorMode === "education") {
@@ -356,6 +377,18 @@ function tileColorCSS(d, alpha) {
 function tileSubInfo(r) {
   if (colorMode === "exposure") {
     return (r.exposure != null ? r.exposure + "/10" : "") +
+           (r.jobs ? " \u00b7 " + formatNumber(r.jobs) + " jobs" : "");
+  }
+  if (colorMode === "advantage") {
+    return (r.advantage != null ? r.advantage + "/10" : "") +
+           (r.jobs ? " \u00b7 " + formatNumber(r.jobs) + " jobs" : "");
+  }
+  if (colorMode === "growth") {
+    return (r.growth != null ? r.growth + "/10" : "") +
+           (r.jobs ? " \u00b7 " + formatNumber(r.jobs) + " jobs" : "");
+  }
+  if (colorMode === "opportunity") {
+    return (r.opportunity != null ? r.opportunity + "/10" : "") +
            (r.jobs ? " \u00b7 " + formatNumber(r.jobs) + " jobs" : "");
   }
   if (colorMode === "outlook") {
@@ -513,14 +546,40 @@ function formatNumber(n) {
 }
 function formatPay(n) { return n == null ? "\u2014" : "$" + n.toLocaleString(); }
 
+function aiScoresTooltipLines(d) {
+  const lines = [];
+  if (d.advantage != null) lines.push(`<span style="color:${advantageColor(d.advantage, 1)}">AI Advantage: ${d.advantage}/10</span>`);
+  if (d.growth != null) lines.push(`<span style="color:${growthColor(d.growth, 1)}">AI Growth: ${d.growth}/10</span>`);
+  if (d.opportunity != null) lines.push(`<span style="color:${opportunityColor(d.opportunity, 1)}">AI Opportunity: ${d.opportunity}/10</span>`);
+  if (d.exposure != null) lines.push(`<span style="color:${exposureColor(d.exposure, 1)}">AI Exposure: ${d.exposure}/10</span>`);
+  return lines.join("<br>");
+}
+
 function tooltipHighlight(d) {
-  if (colorMode === "exposure") {
-    const v = d.exposure;
-    if (v == null) return "";
-    const color = exposureColor(v, 1);
-    return `<span style="color:${color};font-weight:600;">Digital AI Exposure: ${v}/10</span>` +
-      `<div style="margin-top:3px;height:4px;background:rgba(255,255,255,0.08);border-radius:2px;">` +
-      `<div style="height:100%;width:${v * 10}%;background:${color};border-radius:2px;"></div></div>`;
+  const isAILayer = ["exposure", "advantage", "growth", "opportunity"].includes(colorMode);
+  if (isAILayer) {
+    // Show all available AI scores
+    const primary = colorMode === "exposure" ? d.exposure
+      : colorMode === "advantage" ? d.advantage
+      : colorMode === "growth" ? d.growth
+      : d.opportunity;
+    const colorFn = colorMode === "exposure" ? exposureColor
+      : colorMode === "advantage" ? advantageColor
+      : colorMode === "growth" ? growthColor
+      : opportunityColor;
+    const label = colorMode === "exposure" ? "Digital AI Exposure"
+      : colorMode === "advantage" ? "AI Advantage"
+      : colorMode === "growth" ? "AI Growth"
+      : "AI Opportunity";
+    let html = "";
+    if (primary != null) {
+      const color = colorFn(primary, 1);
+      html += `<span style="color:${color};font-weight:600;">${label}: ${primary}/10</span>` +
+        `<div style="margin-top:3px;height:4px;background:rgba(255,255,255,0.08);border-radius:2px;">` +
+        `<div style="height:100%;width:${primary * 10}%;background:${color};border-radius:2px;"></div></div>`;
+    }
+    html += `<div style="margin-top:5px;font-size:11px;line-height:1.6;">${aiScoresTooltipLines(d)}</div>`;
+    return html;
   } else if (colorMode === "outlook") {
     const v = d.outlook;
     if (v == null) return "";
@@ -554,7 +613,11 @@ function showTooltip(d, mx, my) {
     <span class="label">Jobs (2024)</span><span class="value">${formatNumber(d.jobs)}</span>
     <span class="label">Outlook</span><span class="value">${d.outlook != null ? d.outlook + '%' : '\u2014'} ${d.outlook_desc ? '(' + d.outlook_desc + ')' : ''}</span>
     <span class="label">Education</span><span class="value">${d.education || '\u2014'}</span>`;
-  tt.querySelector(".tt-rationale").textContent = colorMode === "exposure" ? (d.exposure_rationale || "") : "";
+  const rationale = colorMode === "exposure" ? (d.exposure_rationale || "")
+    : colorMode === "advantage" ? (d.advantage_rationale || "")
+    : colorMode === "growth" ? (d.growth_rationale || "")
+    : colorMode === "opportunity" ? [d.advantage_rationale, d.growth_rationale].filter(Boolean).join(" | ") : "";
+  tt.querySelector(".tt-rationale").textContent = rationale;
   let tx = mx + 16, ty = my - 16;
   if (tx + 340 > window.innerWidth) tx = mx - 356;
   if (ty < 10) ty = my + 16;
@@ -629,6 +692,9 @@ function updateStats() {
   if (colorMode === "outlook") updateOutlookStats(totalJobs);
   else if (colorMode === "pay") updatePayStats(totalJobs);
   else if (colorMode === "education") updateEducationStats(totalJobs);
+  else if (colorMode === "advantage") updateAdvantageStats(totalJobs);
+  else if (colorMode === "growth") updateGrowthStats(totalJobs);
+  else if (colorMode === "opportunity") updateOpportunityStats(totalJobs);
   else updateExposureStats(totalJobs);
 }
 
@@ -846,6 +912,66 @@ function updateExposureStats(totalJobs) {
   document.getElementById("block8").innerHTML = "";
 }
 
+// Generic stats builder for 0-10 green-positive AI layers
+function updateGreenLayerStats(totalJobs, key, label, colorFn) {
+  let wS = 0, wC = 0;
+  for (const d of data) { if (d[key] != null && d.jobs) { wS += d[key] * d.jobs; wC += d.jobs; } }
+  const avg = wC > 0 ? wS / wC : 0;
+  document.getElementById("block2").innerHTML = `<h3>Avg. ${label.toLowerCase()}</h3>
+    <div class="stat-big"><span style="color:${colorFn(avg, 1)}">${avg.toFixed(1)}</span></div>
+    <div class="stat-label">job-weighted, 0\u201310</div>`;
+
+  // Histogram
+  const histogram = new Array(11).fill(0);
+  for (const d of data) { if (d[key] != null && d.jobs) histogram[Math.round(d[key])] += d.jobs; }
+  const maxH = Math.max(...histogram);
+  document.getElementById("block3").innerHTML = `<h3>Jobs by ${label.toLowerCase()}</h3>
+    <div class="histogram">${histogram.map((c, i) => `<div class="bar" style="height:${Math.max(2, maxH > 0 ? c / maxH * 100 : 0)}%;background:${colorFn(i, 0.7)}"></div>`).join("")}</div>
+    <div class="hist-labels"><span>0</span><span>5</span><span>10</span></div>`;
+
+  // Tier breakdown
+  const tierDefs = [
+    { label: "Low (0\u20132)", lo: 0, hi: 2, mid: 1 },
+    { label: "Moderate (3\u20134)", lo: 3, hi: 4, mid: 3.5 },
+    { label: "Good (5\u20136)", lo: 5, hi: 6, mid: 5.5 },
+    { label: "High (7\u20138)", lo: 7, hi: 8, mid: 7.5 },
+    { label: "Very high (9\u201310)", lo: 9, hi: 10, mid: 9.5 },
+  ];
+  const tiers = tierDefs.map(t => {
+    let jobs = 0;
+    for (const d of data) { if (d[key] != null && d.jobs && d[key] >= t.lo && d[key] <= t.hi) jobs += d.jobs; }
+    return { ...t, jobs, color: colorFn(t.mid, 1) };
+  });
+  document.getElementById("block4").innerHTML = `<h3>${label} tiers</h3><div class="tier-bar">${renderTiers(tiers, totalJobs)}</div>`;
+
+  // Cross: by pay
+  const byPay = weightedAvgByGroups(PAY_BANDS, (d, g) => d.pay != null && d.pay >= g.min && d.pay < g.max, d => d[key]);
+  document.getElementById("block5").innerHTML = `<h3>${label} by pay</h3><div class="hbar-chart">${renderHbars(byPay.map(g => ({
+    label: g.label, val: g.avg.toFixed(1), pct: g.avg / 10 * 100, color: colorFn(g.avg, 0.8)
+  })))}</div>`;
+
+  // Cross: by education
+  const byEdu = weightedAvgByGroups(EDU_GROUPS, (d, g) => g.match.includes(d.education), d => d[key]);
+  document.getElementById("block6").innerHTML = `<h3>${label} by education</h3><div class="hbar-chart">${renderHbars(byEdu.map(g => ({
+    label: g.label, val: g.avg.toFixed(1), pct: g.avg / 10 * 100, color: colorFn(g.avg, 0.8)
+  })))}</div>`;
+
+  document.getElementById("block7").innerHTML = "";
+  document.getElementById("block8").innerHTML = "";
+}
+
+function updateAdvantageStats(totalJobs) {
+  updateGreenLayerStats(totalJobs, "advantage", "Advantage", advantageColor);
+}
+
+function updateGrowthStats(totalJobs) {
+  updateGreenLayerStats(totalJobs, "growth", "Growth", growthColor);
+}
+
+function updateOpportunityStats(totalJobs) {
+  updateGreenLayerStats(totalJobs, "opportunity", "Opportunity", opportunityColor);
+}
+
 // ── Events ─────────────────────────────────────────────────────────────
 
 canvas.addEventListener("mousemove", (e) => {
@@ -861,10 +987,13 @@ function resize() { dpr = window.devicePixelRatio || 1; layout(); draw(); }
 // ── Legend gradient ────────────────────────────────────────────────────
 
 const LEGEND_CONFIG = {
-  exposure:  { low: "Low", high: "High" },
-  outlook:   { low: "Declining", high: "Growing" },
-  pay:       { low: "$25K", high: "$250K" },
-  education: { low: "No degree", high: "Doctoral" },
+  exposure:    { low: "Low", high: "High" },
+  advantage:   { low: "Low", high: "High" },
+  growth:      { low: "Shrinking", high: "Explosive" },
+  opportunity: { low: "Low", high: "High" },
+  outlook:     { low: "Declining", high: "Growing" },
+  pay:         { low: "$25K", high: "$250K" },
+  education:   { low: "No degree", high: "Doctoral" },
 };
 
 function drawGradientLegend() {
@@ -872,7 +1001,12 @@ function drawGradientLegend() {
   const gctx = c.getContext("2d");
   for (let x = 0; x < 80; x++) {
     const t = x / 79;
-    gctx.fillStyle = colorMode === "exposure" ? greenRedCSS(t, 1) : greenRedCSS(1 - t, 1);
+    if (colorMode === "exposure") {
+      gctx.fillStyle = greenRedCSS(t, 1);
+    } else {
+      // All other modes: low=red/left, high=green/right
+      gctx.fillStyle = greenRedCSS(1 - t, 1);
+    }
     gctx.fillRect(x, 0, 1, 8);
   }
   const cfg = LEGEND_CONFIG[colorMode];


### PR DESCRIPTION
## Summary

The existing "Digital AI Exposure" layer captures how much AI will *reshape* a job — but that single lens skews negative. A software developer scoring 9/10 feels alarming, even though demand for developers may actually grow. We wanted additional lenses to explore the positive side of AI's impact on occupations:

- **AI Advantage** (0–10): How much can a worker amplify their productivity and competitive edge by adopting AI tools? Scored via LLM with anchors from "minimal — work is physical/manual" (0) to "maximum — AI transforms every core task" (10).
- **AI Growth** (0–10): How much will AI expand demand, create new sub-roles, or grow the market for this occupation? Anchors range from "shrinking — AI directly replaces demand" (0) to "explosive — entirely new demand driven by AI" (10).
- **AI Opportunity** (0–10): Composite average of Advantage and Growth.

These complement rather than replace the existing exposure layer. Together, the four AI layers let you explore questions like: *which occupations are highly exposed but also have high opportunity?*

## Changes

- **`score.py`**: Added `--metric` CLI flag (`exposure` | `advantage` | `growth`) with dedicated LLM prompts and separate output files per metric. Default (`exposure`) behavior is unchanged.
- **`build_site_data.py`**: Merges `scores_advantage.json` and `scores_growth.json` alongside existing `scores.json`, computes composite opportunity score. Gracefully handles missing files.
- **`site/index.html`**: 3 new layer toggle buttons, reuses the existing green↔red color scale (flipped: green = high = good), new stats dashboards, tooltips show all AI scores when hovering in any AI layer.
- **`make_prompt.py`**: Adds Advantage, Growth, Opportunity columns to the markdown report when score data is available.

Fully additive — zero changes to the existing exposure pipeline, UI, or data format.

## Test plan

- [ ] `uv run python score.py` (no args) still works exactly as before
- [ ] `uv run python score.py --metric advantage --start 0 --end 10` scores 10 occupations
- [ ] `uv run python score.py --metric growth --start 0 --end 10` scores 10 occupations
- [ ] `uv run python build_site_data.py` merges all score files into `site/data.json`
- [ ] All 7 layer buttons render correctly in `site/index.html`
- [ ] Green-positive color scale for new layers (vs red-positive for exposure)
- [ ] Tooltips show all AI scores when hovering in any AI layer

Sidney Hori Hawthorne
X: @sid_hori
linkedin: https://www.linkedin.com/in/sidney-hori/
sidney@aeonixtech.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)